### PR TITLE
set php_codesniffer to ~2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"squizlabs/php_codesniffer": ">=2.7.0"
+		"squizlabs/php_codesniffer": "~2.7"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.3"


### PR DESCRIPTION
because since 3.0 it has different folder structure

https://travis-ci.org/hellowearemito/yii2-sentry/jobs/298851711